### PR TITLE
DTO들에 Serializable 인터페이스 제거

### DIFF
--- a/project-board/src/main/java/com/fastcampus/project_board/DTO/response/ArticleCommentResponse.java
+++ b/project-board/src/main/java/com/fastcampus/project_board/DTO/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.project_board.DTO.response;
 
 import com.fastcampus.project_board.DTO.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content,LocalDateTime createdAt, String email, String nickname){
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/project-board/src/main/java/com/fastcampus/project_board/DTO/response/ArticleResponse.java
+++ b/project-board/src/main/java/com/fastcampus/project_board/DTO/response/ArticleResponse.java
@@ -3,7 +3,6 @@ package com.fastcampus.project_board.DTO.response;
 import com.fastcampus.project_board.DTO.ArticleCommentDto;
 import com.fastcampus.project_board.DTO.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -14,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+)  {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname){
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/project-board/src/main/java/com/fastcampus/project_board/DTO/response/ArticleWithCommentsResponse.java
+++ b/project-board/src/main/java/com/fastcampus/project_board/DTO/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.project_board.DTO.response;
 
 import com.fastcampus.project_board.DTO.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id , String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses){
         return new ArticleWithCommentsResponse(id,title,content,hashtag,createdAt,email,nickname,articleCommentResponses);


### PR DESCRIPTION
JPA Buddy를 이용해 작성한 DTO들인데,
자동으로 `implements Serializable`이 들어가버림
해당 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제