### PR TITLE
오타 수정: 삭제 기능 정상화

### DIFF
--- a/project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/project-board/src/main/resources/templates/articles/detail.th.xml
@@ -12,7 +12,7 @@
         <attr sel="#article-content/pre" th:text="*{content}"/>
 
         <attr sel="#article-buttons">
-            <attr sel="#delete-article-form" th:action="'/articles' + *{id} + '/delete'" th:method="post">
+            <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
         </attr>


### PR DESCRIPTION
게시글 삭제 버튼을 누르면 에러 페이지가 나오는 것을 확인,
url부분에서 article과 {id}를 구분하지 않고 연결되어서 발생한 오류이므로 수정하였다.